### PR TITLE
Add the decision_eq

### DIFF
--- a/lib/Decision.v
+++ b/lib/Decision.v
@@ -24,6 +24,13 @@ Open Scope Z_scope.
 Class Decision (P: Prop) := decide: {P} + {~P}.
 Arguments decide P {_}.
 
+Ltac decision_eq :=
+  unfold Decision;
+  decide equality;
+  try match goal with
+      | |- {?a = ?b} + {?a <> ?b} => apply (decide (a = b))
+      end.
+
 Definition isTrue P `{Decision P} :=
   if decide P then true else false.
 


### PR DESCRIPTION
Use this tactic to prove `Decision (n = m)` for simple inductive types.
For example:
```coq
Inductive FOO :=
| FOO_A
| FOO_B (bar: Z).

Instance decide_FOO_eq : forall (m n : FOO), Decision (m = n).
Proof. decision_eq. Qed.
```